### PR TITLE
Fix compatibility with parallel stream (master)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>pl.pragmatists</groupId>
 			<artifactId>JUnitParams</artifactId>
-			<version>1.0.3</version>
+			<version>1.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/test/java/com/nurkiewicz/java8/J07b_StreamReduceTest.java
+++ b/src/test/java/com/nurkiewicz/java8/J07b_StreamReduceTest.java
@@ -1,15 +1,30 @@
 package com.nurkiewicz.java8;
 
+import com.nurkiewicz.java8.util.StreamTestFixture;
+import com.nurkiewicz.java8.util.StreamTestFixture.StreamParallelism;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
+import static com.nurkiewicz.java8.util.StreamTestFixture.PARALLEL_TEST_CASE_NAME_FORMAT;
+import static com.nurkiewicz.java8.util.StreamTestFixture.changeStreamParallelism;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 @Ignore
+@RunWith(JUnitParamsRunner.class)
 public class J07b_StreamReduceTest {
+
+	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	@Test
 	public void shouldAddNumbersUsingReduce() throws Exception {
@@ -17,10 +32,33 @@ public class J07b_StreamReduceTest {
 		final List<Integer> input = Arrays.asList(2, 3, 5, 7);
 
 		//when
-		final int sum = input.stream().reduce(0, (acc, x) -> acc + x);
+		final int sum = input.stream().reduce(0, (acc, x) -> acc + x);  //could be simplified to Integer::sum
 
 		//then
 		assertThat(sum).isEqualTo(2 + 3 + 5 + 7);
+	}
+
+	@Test
+	public void shouldConcatNumbersBrokenWithParallelStream() throws Exception {
+		//given
+		final List<Integer> input = Arrays.asList(2, 3, 5, 7);
+
+		//when
+		final String result = input.stream()    //WARNING: Broken with parallel stream
+				.reduce(
+						new StringBuilder(),
+						(acc, x) -> {
+							log.info("Accumulator '{}', '{}'", acc, x);
+							return acc.append(x);
+						},
+						(sb1, sb2) -> {
+							log.info("Combiner '{}', '{}'", sb1, sb2);
+							return sb1.append(sb2);
+						})
+				.toString();
+
+		//then
+		assertThat(result).isEqualToIgnoringCase("2357");
 	}
 
 	@Test
@@ -29,12 +67,11 @@ public class J07b_StreamReduceTest {
 		final List<Integer> input = Arrays.asList(2, 3, 5, 7);
 
 		//when
-		final String result = input
-				.stream()
+		final String result = input.stream()
 				.reduce(
 						new StringBuilder(),
-						(acc, x) -> acc.append(x),
-						(sb1, sb2) -> sb1.append(sb2))
+						(acc, x) -> new StringBuilder().append(acc).append(x),
+						(sb1, sb2) -> new StringBuilder().append(sb1).append(sb2))
 				.toString();
 
 		//then
@@ -54,24 +91,30 @@ public class J07b_StreamReduceTest {
 	}
 
 	@Test
-	public void shouldSimulateMapUsingReduce() throws Exception {
+	@Parameters(source = StreamTestFixture.class)
+	@TestCaseName(PARALLEL_TEST_CASE_NAME_FORMAT)
+	public void shouldSimulateMapUsingReduce(StreamParallelism requestedParallelism) {
 		//given
 		final List<Integer> input = Arrays.asList(2, 3, 5, 7);
+		final Stream<Integer> stream = changeStreamParallelism(input.stream(), requestedParallelism);
 
 		//when
-		final List<Integer> doubledPrimes = null;   //input.stream()...
+		final List<Integer> doubledPrimes = null;   //stream...
 
 		//then
 		assertThat(doubledPrimes).containsExactly(2 * 2, 3 * 2, 5 * 2, 7 * 2);
 	}
 
 	@Test
-	public void shouldSimulateFilterUsingReduce() throws Exception {
+	@Parameters(source = StreamTestFixture.class)
+	@TestCaseName(PARALLEL_TEST_CASE_NAME_FORMAT)
+	public void shouldSimulateFilterUsingReduce(StreamParallelism requestedParallelism) {
 		//given
 		final List<Integer> input = Arrays.asList(2, 3, 4, 5, 6);
+		final Stream<Integer> stream = changeStreamParallelism(input.stream(), requestedParallelism);
 
 		//when
-		final List<Integer> onlyEvenNumbers = null;   //input.stream()...
+		final List<Integer> onlyEvenNumbers = null;   //stream...
 
 		//then
 		assertThat(onlyEvenNumbers).containsExactly(2, 4, 6);

--- a/src/test/java/com/nurkiewicz/java8/util/StreamTestFixture.java
+++ b/src/test/java/com/nurkiewicz/java8/util/StreamTestFixture.java
@@ -1,0 +1,37 @@
+package com.nurkiewicz.java8.util;
+
+import java.util.stream.Stream;
+
+import static junitparams.JUnitParamsRunner.$;
+
+public class StreamTestFixture {
+
+	public static final String PARALLEL_TEST_CASE_NAME_FORMAT = "[{index}] {method} ({0})";
+
+	public enum StreamParallelism {
+		SEQUENTIAL, PARALLEL;
+
+		@Override
+		public String toString() {
+			return name().toLowerCase();
+		}
+	}
+
+	@SuppressWarnings("unused")
+	public static Object[] provideTrueFalse() {
+		return $(StreamParallelism.SEQUENTIAL, StreamParallelism.PARALLEL);
+	}
+
+	public static <T> Stream<T> changeStreamParallelism(Stream<T> stream, StreamParallelism requestedParallelism) {
+		//StreamParallelism could have a field with Function<Stream<?>, Stream<?>> to eliminate switch-case,
+		// but the implementation looks awkward
+		switch (requestedParallelism) {
+			case SEQUENTIAL:
+				return stream.sequential();
+			case PARALLEL:
+				return stream.parallel();
+			default:
+				throw new IllegalArgumentException("Unexpected enum value: " + requestedParallelism);
+		}
+	}
+}


### PR DESCRIPTION
`identity` value provided in reduce is reused across threads and the accumulation operation needs to work on a copy. For more memory efficient reduce operation a dedicated `Collector` with mutable internal accumulator can be used.

Also added tests to verify that custom user implementation is parallel stream compatible and a logger to show in practice how values change in each step.
